### PR TITLE
docs: improve Claude Desktop restart instructions in troubleshooting

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1856,6 +1856,16 @@ tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 2. Make sure the path to your project is absolute and not relative
 3. Restart Claude for Desktop completely
 
+<Note>
+
+**Important:** To properly restart Claude for Desktop, you must fully quit the application:
+
+- **Windows:** Right-click the Claude icon in the system tray (which may be hidden in the "hidden icons" menu) and select "Quit" or "Exit"
+- **macOS:** Use Cmd+Q or select "Quit Claude" from the menu bar
+- Simply closing the window does not fully quit the application and your MCP server configuration changes will not take effect
+
+</Note>
+
 **Tool calls failing silently**
 
 If Claude attempts to use the tools but they fail:

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1856,15 +1856,16 @@ tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 2. Make sure the path to your project is absolute and not relative
 3. Restart Claude for Desktop completely
 
-<Note>
+<Warning>
 
-**Important:** To properly restart Claude for Desktop, you must fully quit the application:
+To properly restart Claude for Desktop, you must fully quit the application:
 
-- **Windows:** Right-click the Claude icon in the system tray (which may be hidden in the "hidden icons" menu) and select "Quit" or "Exit"
-- **macOS:** Use Cmd+Q or select "Quit Claude" from the menu bar
-- Simply closing the window does not fully quit the application and your MCP server configuration changes will not take effect
+- **Windows**: Right-click the Claude icon in the system tray (which may be hidden in the "hidden icons" menu) and select "Quit" or "Exit".
+- **macOS**: Use Cmd+Q or select "Quit Claude" from the menu bar.
 
-</Note>
+Simply closing the window does not fully quit the application, and your MCP server configuration changes will not take effect.
+
+</Warning>
 
 **Tool calls failing silently**
 


### PR DESCRIPTION
## Description

Fixes #1499

This PR improves the Claude Desktop restart instructions in the build-server.mdx documentation to address user confusion about properly restarting Claude Desktop after making MCP server configuration changes.

## Changes Made

- Added detailed restart instructions in the troubleshooting section


## Testing

- [x] Documentation changes only - no code changes
- [x] Verified all programming language tabs have consistent, non-repetitive instructions
- [x] Confirmed troubleshooting section contains comprehensive restart guidance
- [x] No linting errors introduced